### PR TITLE
1.20.1 fix issue#2 | v 1.0.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 apply plugin: 'net.minecraftforge.gradle'
 
-version = '1.0.2'
+version = '1.0.3'
 group = 'com.agustinbenitez.indexer'
 archivesBaseName = 'indexer-1.20.1-v'
 

--- a/src/main/java/com/agustinbenitez/indexer/item/IndexerManualItem.java
+++ b/src/main/java/com/agustinbenitez/indexer/item/IndexerManualItem.java
@@ -33,11 +33,10 @@ public class IndexerManualItem extends Item {
         ItemStack itemstack = player.getItemInHand(hand);
         
         if (level.isClientSide()) {
-            // Usar DistExecutor para asegurarse de que el código del cliente solo se ejecute en el cliente
-            DistExecutor.safeRunWhenOn(Dist.CLIENT, () -> () -> openManualScreen());
+            openManualScreen();
         }
 
-        return InteractionResultHolder.sidedSuccess(itemstack, level.isClientSide());
+        return InteractionResultHolder.success(itemstack);
     }
     
     @OnlyIn(Dist.CLIENT)

--- a/src/main/java/com/agustinbenitez/indexer/item/IndexerManualItem.java
+++ b/src/main/java/com/agustinbenitez/indexer/item/IndexerManualItem.java
@@ -9,6 +9,9 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.fml.DistExecutor;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -30,10 +33,15 @@ public class IndexerManualItem extends Item {
         ItemStack itemstack = player.getItemInHand(hand);
         
         if (level.isClientSide()) {
-            // Abrir la pantalla GUI del manual en el cliente
-            net.minecraft.client.Minecraft.getInstance().setScreen(new com.agustinbenitez.indexer.screen.IndexerManualScreen());
+            // Usar DistExecutor para asegurarse de que el código del cliente solo se ejecute en el cliente
+            DistExecutor.safeRunWhenOn(Dist.CLIENT, () -> () -> openManualScreen());
         }
 
         return InteractionResultHolder.sidedSuccess(itemstack, level.isClientSide());
+    }
+    
+    @OnlyIn(Dist.CLIENT)
+    private static void openManualScreen() {
+        net.minecraft.client.Minecraft.getInstance().setScreen(new com.agustinbenitez.indexer.screen.IndexerManualScreen());
     }
 }

--- a/src/main/java/com/agustinbenitez/indexer/screen/DropBoxScreen.java
+++ b/src/main/java/com/agustinbenitez/indexer/screen/DropBoxScreen.java
@@ -7,7 +7,10 @@ import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 
+@OnlyIn(Dist.CLIENT)
 public class DropBoxScreen extends AbstractContainerScreen<DropBoxMenu> {
     private static final ResourceLocation TEXTURE = new ResourceLocation("minecraft", "textures/gui/container/generic_54.png");
 

--- a/src/main/java/com/agustinbenitez/indexer/screen/IndexerConnectorScreen.java
+++ b/src/main/java/com/agustinbenitez/indexer/screen/IndexerConnectorScreen.java
@@ -7,7 +7,10 @@ import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 
+@OnlyIn(Dist.CLIENT)
 public class IndexerConnectorScreen extends AbstractContainerScreen<IndexerConnectorMenu> {
     private static final ResourceLocation TEXTURE = new ResourceLocation(IndexerMod.MOD_ID, "textures/gui/menu_conector.png");
     

--- a/src/main/java/com/agustinbenitez/indexer/screen/IndexerControllerScreen.java
+++ b/src/main/java/com/agustinbenitez/indexer/screen/IndexerControllerScreen.java
@@ -9,8 +9,11 @@ import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 import java.text.DecimalFormat;
 
+@OnlyIn(Dist.CLIENT)
 public class IndexerControllerScreen extends AbstractContainerScreen<IndexerControllerMenu> {
     private static final ResourceLocation TEXTURE = new ResourceLocation("minecraft", "textures/gui/container/generic_54.png");
     

--- a/src/main/java/com/agustinbenitez/indexer/screen/IndexerManualScreen.java
+++ b/src/main/java/com/agustinbenitez/indexer/screen/IndexerManualScreen.java
@@ -6,11 +6,14 @@ import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 
 /**
  * Pantalla GUI para el manual del Indexer.
  * Muestra instrucciones paso a paso con imágenes y permite navegar entre páginas.
  */
+@OnlyIn(Dist.CLIENT)
 public class IndexerManualScreen extends Screen {
     // Constantes para la pantalla
     private static final int SCREEN_WIDTH = 271;

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -4,7 +4,7 @@ license="All Rights Reserved"
 
 [[mods]]
 modId="indexer"
-version="1.0.2"
+version="1.0.3"
 displayName="Indexer"
 authors="AgustinBenitez"
 logoFile="assets/indexer/textures/gui/logo.png"


### PR DESCRIPTION

### ISSUE #2 
Mod crashes dedicated server due to client-only class usage

I'm trying to run it on a d
/edicated Minecraft Forge server (version 1.20.1), but the server crashes during startup with the following error:
```
Caused by: java.lang.RuntimeException: 
Attempted to load class net/minecraft/client/gui/screens/Screen for invalid dist DEDICATED_SERVER
	at net.minecraftforge.fml.loading.RuntimeDistCleaner.processClassWithFlags(RuntimeDistCleaner.java:57)
	at com.agustinbenitez.indexer.init.ModItems.lambda$static$4(ModItems.java:32)
This means the mod is trying to load a client-only class (Screen) on the server, which is not allowed. This usually happens when code referencing net.minecraft.client.* runs on both client and server without being properly wrapped.
```